### PR TITLE
Update CI for Support Apple Silicon

### DIFF
--- a/.github/workflows/ci-krkrsdl2.yml
+++ b/.github/workflows/ci-krkrsdl2.yml
@@ -233,7 +233,7 @@
       ]
     },
     "build-macos-cmake" : {
-      "runs-on" : "macos-11",
+      "runs-on" : "macos-14",
       "timeout-minutes" : 20,
       "steps" : [
         {
@@ -249,7 +249,7 @@
         },
         {
           "name" : "Configure project",
-          "run" : "cmake -S . -B build"
+          "run" : "cmake -DCMAKE_OSX_ARCHITECTURES='arm64;x86_64' -S . -B build"
         },
         {
           "name" : "Build project",

--- a/.github/workflows/ci-krkrsdl2.yml
+++ b/.github/workflows/ci-krkrsdl2.yml
@@ -282,7 +282,7 @@
       "steps" : [
         {
           "name" : "Download all artifacts",
-          "uses" : "actions/download-artifact@v3"
+          "uses" : "actions/download-artifact@master"
         },
         {
           "name" : "Prepare artifacts for release",


### PR DESCRIPTION
Changed for running on Apple Silicon without Rosetta 2.
I have confirmed that it runs on an M1 Macbook Air and is a universal binary.

<img width="981" alt="image" src="https://github.com/krkrsdl2/json/assets/58556570/ed5486d1-af17-442e-8944-8c038248edc2">
<img width="343" alt="image" src="https://github.com/krkrsdl2/json/assets/58556570/1fc85cf4-9806-45e4-a372-59210842bb15">
<img width="456" alt="image" src="https://github.com/krkrsdl2/json/assets/58556570/f9e316ee-29ea-4d68-823a-910051750ecb">
